### PR TITLE
Make the get and set method of the `geomagicdriver` device non-blocking, similar to te rest of existing YARP devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 The minimum version of YARP required to use `haptic-devices` is now 3.2 .
 
 ### Changed
+- In `geomagicdriver`, the `get` and `set` methods are not blocking anymore (see https://github.com/robotology/haptic-devices/issues/10 and https://github.com/robotology/haptic-devices/pull/11).
 - Compilation of `hapticdevicewrapper` and `hapticdeviceclient` is now ON by default.
 - CMake options for compilation of devices changed from `ENABLE_hapticdevicemod_<devicename>` to `ENABLE_<devicename>`.
 


### PR DESCRIPTION
Related issue: https://github.com/robotology/haptic-devices/issues/10 .