### PR TITLE
Implement attach mechanism in haptic device wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,6 @@
 *.app
 
 #build folder
-build
+build*/
+.vscode/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Authors: Ugo Pattacini <ugo.pattacini@iit.it>
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.19)
 project(haptic-devices)
 
-find_package(YARP 3.2 REQUIRED)
+find_package(YARP 3.12 REQUIRED)
 
 set(BUILD_SHARED_LIBS TRUE)
 

--- a/client/hapticdeviceClient.cpp
+++ b/client/hapticdeviceClient.cpp
@@ -8,10 +8,10 @@
  */
 
 #include <string>
+#include <mutex>
 
 #include <yarp/os/Log.h>
 #include <yarp/os/Network.h>
-#include <yarp/os/LockGuard.h>
 
 #include "hapticdeviceClient.h"
 #include "common.h"
@@ -27,7 +27,7 @@ void StatePort::onRead(Bottle &state)
 {
     if (client!=NULL)
     {
-        LockGuard lg(client->mutex);
+        std::lock_guard lg(client->mutex);
         state.write(client->state);
         getEnvelope(client->stamp);
     }
@@ -57,7 +57,7 @@ bool HapticDeviceClient::open(Searchable &config)
 
     string remote=config.find("remote").asString().c_str();
     string local=config.find("local").asString().c_str();
-    verbosity=config.check("verbosity",Value(0)).asInt();
+    verbosity=config.check("verbosity",Value(0)).asInt32();
 
     statePort.open((local+"/state:i").c_str());
     feedbackPort.open((local+"/feedback:o").c_str());
@@ -103,7 +103,7 @@ bool HapticDeviceClient::close()
 /*********************************************************************/
 bool HapticDeviceClient::getPosition(Vector &pos)
 {
-    LockGuard lg(mutex);
+    std::lock_guard lg(mutex);
     pos=state.subVector(0,2);
     return true;
 }
@@ -112,7 +112,7 @@ bool HapticDeviceClient::getPosition(Vector &pos)
 /*********************************************************************/
 bool HapticDeviceClient::getOrientation(Vector &rpy)
 {
-    LockGuard lg(mutex);
+    std::lock_guard lg(mutex);
     rpy=state.subVector(3,5);
     return true;
 }
@@ -121,7 +121,7 @@ bool HapticDeviceClient::getOrientation(Vector &rpy)
 /*********************************************************************/
 bool HapticDeviceClient::getButtons(Vector &buttons)
 {
-    LockGuard lg(mutex);
+    std::lock_guard lg(mutex);
     buttons=state.subVector(6,7);
     return true;
 }
@@ -131,16 +131,16 @@ bool HapticDeviceClient::getButtons(Vector &buttons)
 bool HapticDeviceClient::isCartesianForceModeEnabled(bool &ret)
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::is_cartesian);
+    cmd.addVocab32(hapticdevice::is_cartesian);
     if (!rpcPort.write(cmd,rep))
     {
         yError("*** Haptic Device Client: unable to get reply from Haptic Device Wrapper!");
         return false;
     }
 
-    if (rep.get(0).asVocab()==hapticdevice::ack)
+    if (rep.get(0).asVocab32()==hapticdevice::ack)
     {
-        ret=(rep.get(1).asInt()!=0);
+        ret=(rep.get(1).asInt32()!=0);
         return true;
     }
     else
@@ -152,14 +152,14 @@ bool HapticDeviceClient::isCartesianForceModeEnabled(bool &ret)
 bool HapticDeviceClient::setCartesianForceMode()
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::set_cartesian);
+    cmd.addVocab32(hapticdevice::set_cartesian);
     if (!rpcPort.write(cmd,rep))
     {
         yError("*** Haptic Device Client: unable to get reply from Haptic Device Wrapper!");
         return false;
     }
 
-    return (rep.get(0).asVocab()==hapticdevice::ack);
+    return (rep.get(0).asVocab32()==hapticdevice::ack);
 }
 
 
@@ -167,14 +167,14 @@ bool HapticDeviceClient::setCartesianForceMode()
 bool HapticDeviceClient::setJointTorqueMode()
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::set_joint);
+    cmd.addVocab32(hapticdevice::set_joint);
     if (!rpcPort.write(cmd,rep))
     {
         yError("*** Haptic Device Client: unable to get reply from Haptic Device Wrapper!");
         return false;
     }
 
-    return (rep.get(0).asVocab()==hapticdevice::ack);
+    return (rep.get(0).asVocab32()==hapticdevice::ack);
 }
 
 
@@ -182,25 +182,25 @@ bool HapticDeviceClient::setJointTorqueMode()
 bool HapticDeviceClient::getMaxFeedback(Vector &max)
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::get_max);
+    cmd.addVocab32(hapticdevice::get_max);
     if (!rpcPort.write(cmd,rep))
     {
         yError("*** Haptic Device Client: unable to get reply from Haptic Device Wrapper!");
         return false;
     }
 
-    if (rep.get(0).asVocab()==hapticdevice::ack)
+    if (rep.get(0).asVocab32()==hapticdevice::ack)
     {
         if (Bottle *payload=rep.get(1).asList())
         {
             max.resize(payload->size());
             for (size_t i=0; i<max.length(); i++)
-                max[i]=payload->get(i).asDouble();
-            
+                max[i]=payload->get(i).asFloat64();
+
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -210,7 +210,7 @@ bool HapticDeviceClient::setFeedback(const Vector &fdbck)
 {
     if (fdbck.length()==3)
     {
-        feedbackPort.prepare().read(const_cast<Vector&>(fdbck)); 
+        feedbackPort.prepare().read(const_cast<Vector&>(fdbck));
         feedbackPort.writeStrict();
         return true;
     }
@@ -223,14 +223,14 @@ bool HapticDeviceClient::setFeedback(const Vector &fdbck)
 bool HapticDeviceClient::stopFeedback()
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::stop_feedback);
+    cmd.addVocab32(hapticdevice::stop_feedback);
     if (!rpcPort.write(cmd,rep))
     {
         yError("*** Haptic Device Client: unable to get reply from Haptic Device Wrapper!");
         return false;
     }
 
-    return (rep.get(0).asVocab()==hapticdevice::ack);
+    return (rep.get(0).asVocab32()==hapticdevice::ack);
 }
 
 
@@ -238,31 +238,31 @@ bool HapticDeviceClient::stopFeedback()
 bool HapticDeviceClient::getTransformation(Matrix &T)
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::get_transformation);
+    cmd.addVocab32(hapticdevice::get_transformation);
     if (!rpcPort.write(cmd,rep))
     {
         yError("*** Haptic Device Client: unable to get reply from Haptic Device Wrapper!");
         return false;
     }
 
-    if (rep.get(0).asVocab()==hapticdevice::ack)
+    if (rep.get(0).asVocab32()==hapticdevice::ack)
     {
         if (Bottle *payload=rep.get(1).asList())
         {
-            T.resize(payload->get(0).asInt(),
-                     payload->get(1).asInt());
-            
+            T.resize(payload->get(0).asInt32(),
+                     payload->get(1).asInt32());
+
             if (Bottle *vals=payload->get(2).asList())
             {
                 for (int r=0; r<T.rows(); r++)
                     for (int c=0; c<T.cols(); c++)
-                        T(r,c)=vals->get(T.rows()*r+c).asDouble();
-            
+                        T(r,c)=vals->get(T.rows()*r+c).asFloat64();
+
                 return true;
             }
         }
     }
-    
+
     return false;
 }
 
@@ -271,7 +271,7 @@ bool HapticDeviceClient::getTransformation(Matrix &T)
 bool HapticDeviceClient::setTransformation(const Matrix &T)
 {
     Bottle cmd,rep;
-    cmd.addVocab(hapticdevice::set_transformation);
+    cmd.addVocab32(hapticdevice::set_transformation);
     cmd.addList().read(const_cast<Matrix&>(T));
     if (!rpcPort.write(cmd,rep))
     {
@@ -279,14 +279,13 @@ bool HapticDeviceClient::setTransformation(const Matrix &T)
         return false;
     }
 
-    return (rep.get(0).asVocab()==hapticdevice::ack);
+    return (rep.get(0).asVocab32()==hapticdevice::ack);
 }
 
 
 /*********************************************************************/
 Stamp HapticDeviceClient::getLastInputStamp()
 {
-    LockGuard lg(mutex);
+    std::lock_guard lg(mutex);
     return stamp;
 }
-

--- a/client/hapticdeviceClient.h
+++ b/client/hapticdeviceClient.h
@@ -10,13 +10,14 @@
 #ifndef __HAPTICDEVICE_CLIENT__
 #define __HAPTICDEVICE_CLIENT__
 
+#include <mutex>
+
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/dev/IHapticDevice.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
@@ -48,17 +49,17 @@ class HapticDeviceClient : public yarp::dev::DeviceDriver,
                            public yarp::dev::IPreciselyTimed,
                            public yarp::dev::IHapticDevice
 {
-protected:    
+protected:
     int verbosity;
 
     friend StatePort;
     StatePort                                statePort;
     yarp::os::BufferedPort<yarp::os::Bottle> feedbackPort;
-    yarp::os::RpcClient                      rpcPort;    
-    
+    yarp::os::RpcClient                      rpcPort;
+
     yarp::sig::Vector state;
     yarp::os::Stamp stamp;
-    yarp::os::Mutex mutex;
+    std::mutex mutex;
 
 public:
     HapticDeviceClient();
@@ -85,5 +86,3 @@ public:
 };
 
 #endif
-
-

--- a/common/common.h
+++ b/common/common.h
@@ -14,18 +14,16 @@
 
 namespace hapticdevice {
     enum {
-        ack                = yarp::os::createVocab('a','c','k'),
-        nack               = yarp::os::createVocab('n','a','c','k'),
-        get_transformation = yarp::os::createVocab('g','t','r','a'),
-        set_transformation = yarp::os::createVocab('s','t','r','a'),
-        stop_feedback      = yarp::os::createVocab('s','t','o','p'),
-        is_cartesian       = yarp::os::createVocab('i','s','f'),
-        set_cartesian      = yarp::os::createVocab('s','c','a','r'),
-        set_joint          = yarp::os::createVocab('s','j','n','t'),
-        get_max            = yarp::os::createVocab('g','m','a','x')
+        ack                = yarp::os::createVocab32('a','c','k'),
+        nack               = yarp::os::createVocab32('n','a','c','k'),
+        get_transformation = yarp::os::createVocab32('g','t','r','a'),
+        set_transformation = yarp::os::createVocab32('s','t','r','a'),
+        stop_feedback      = yarp::os::createVocab32('s','t','o','p'),
+        is_cartesian       = yarp::os::createVocab32('i','s','f'),
+        set_cartesian      = yarp::os::createVocab32('s','c','a','r'),
+        set_joint          = yarp::os::createVocab32('s','j','n','t'),
+        get_max            = yarp::os::createVocab32('g','m','a','x')
     };
 }
 
 #endif
-
-

--- a/drivers/geomagic/geomagicDriver.cpp
+++ b/drivers/geomagic/geomagicDriver.cpp
@@ -41,7 +41,7 @@ bool GeomagicDriver::open(Searchable &config)
 
     if (!configured)
     {
-        verbosity=config.check("verbosity",Value(0)).asInt();
+        verbosity=config.check("verbosity",Value(0)).asInt32();
         if (verbosity>0)
             yInfo("*** Geomagic Driver: opened");
         name=config.check("device-id",
@@ -302,7 +302,7 @@ bool GeomagicDriver::stopFeedback()
     hDeviceData.m_forceValues[0]=0.0;
     hDeviceData.m_forceValues[1]=0.0;
     hDeviceData.m_forceValues[2]=0.0;
-    
+
     return writeSuccessful;
 }
 
@@ -412,19 +412,19 @@ GeomagicDriver::updateDeviceCallback(void *pUserData)
 
     /* Retrieve the current button(s). */
     hdGetIntegerv(HD_CURRENT_BUTTONS, &nButtons);
-    
+
     /* In order to get the specific button 1 state, we use a bitmask to
        test for the HD_DEVICE_BUTTON_1 bit. */
-    pDeviceData->m_button1State = 
+    pDeviceData->m_button1State =
         (nButtons & HD_DEVICE_BUTTON_1) ? HD_TRUE : HD_FALSE;
- 
+
     /* In order to get the specific button 2 state, we use a bitmask to
        test for the HD_DEVICE_BUTTON_2 bit. */
-    pDeviceData->m_button2State = 
+    pDeviceData->m_button2State =
         (nButtons & HD_DEVICE_BUTTON_2) ? HD_TRUE : HD_FALSE;
- 
+
     /* Get the current location of the device (HD_GET_CURRENT_POSITION)
-       We declare a vector of three doubles since hdGetDoublev returns 
+       We declare a vector of three doubles since hdGetDoublev returns
        the information in a vector of size 3. */
     hdGetDoublev(HD_CURRENT_POSITION, pDeviceData->m_devicePosition);
 
@@ -444,7 +444,7 @@ GeomagicDriver::updateDeviceCallback(void *pUserData)
     /* Copy the position into our device_data tructure. */
     hdEndFrame(hdGetCurrentDevice());
 
-    return HD_CALLBACK_CONTINUE;    
+    return HD_CALLBACK_CONTINUE;
 }
 
 
@@ -471,4 +471,3 @@ GeomagicDriver::updateMotorForceDataCallback(void *pUserData)
     pThis->innerDeviceData.m_forceValues[2]=pThis->hDeviceData.m_forceValues[2];
     return HD_CALLBACK_DONE;
 }
-

--- a/examples/teleop-icub/main.cpp
+++ b/examples/teleop-icub/main.cpp
@@ -41,7 +41,7 @@ protected:
     IVelocityControl2 *ivel;
     IGazeControl      *igaze;
     IHapticDevice     *igeo;
-    
+
     BufferedPort<Bottle> forceFbPort;
     RpcClient simPort;
 
@@ -80,12 +80,12 @@ public:
         string name=rf.check("name",Value("teleop-icub")).asString().c_str();
         string robot=rf.check("robot",Value("icub")).asString().c_str();
         string geomagic=rf.check("geomagic",Value("geomagic")).asString().c_str();
-        double Tp2p=rf.check("Tp2p",Value(1.0)).asDouble();
+        double Tp2p=rf.check("Tp2p",Value(1.0)).asFloat64();
         part=rf.check("part",Value("right_arm")).asString().c_str();
         simulator=rf.check("simulator",Value("off")).asString()=="on";
         gaze=rf.check("gaze",Value("off")).asString()=="on";
-        minForce=fabs(rf.check("min-force-feedback",Value(3.0)).asDouble());
-        maxForce=fabs(rf.check("max-force-feedback",Value(15.0)).asDouble());
+        minForce=fabs(rf.check("min-force-feedback",Value(3.0)).asFloat64());
+        maxForce=fabs(rf.check("max-force-feedback",Value(15.0)).asFloat64());
         bool torso=rf.check("torso",Value("on")).asString()=="on";
 
         Property optGeo("(device hapticdeviceclient)");
@@ -130,7 +130,7 @@ public:
             if (simulator)
                 simPort.close();
             if (gaze)
-                drvGaze.close();            
+                drvGaze.close();
             return false;
         }
         drvCart.view(iarm);
@@ -162,7 +162,7 @@ public:
             dof[1]=0.0;
         iarm->setDOF(dof,dof);
         iarm->setTrajTime(Tp2p);
-        
+
         Vector accs,poss;
         for (int i=0; i<9; i++)
         {
@@ -174,7 +174,7 @@ public:
         }
         poss[0]=20.0;
         poss[1]=70.0;
-        
+
         imod->setControlModes(joints.size(),joints.getFirst(),modes.getFirst());
         ipos->setRefAccelerations(joints.size(),joints.getFirst(),accs.data());
         ipos->setRefSpeeds(joints.size(),joints.getFirst(),vels.data());
@@ -190,11 +190,11 @@ public:
             vels.push_back(40.0);
         }
         vels[vels.length()-1]=100.0;
-        
+
         s0=s1=idle;
         c0=c1=0;
         onlyXYZ=true;
-        
+
         stateStr[idle]="idle";
         stateStr[triggered]="triggered";
         stateStr[running]="running";
@@ -207,7 +207,7 @@ public:
         igeo->setTransformation(SE3inv(T));
         igeo->setCartesianForceMode();
         igeo->getMaxFeedback(maxFeedback);
-        
+
         Tsim=zeros(4,4);
         Tsim(0,1)=-1.0;
         Tsim(1,2)=1.0;  Tsim(1,3)=0.5976;
@@ -226,7 +226,7 @@ public:
             cmd.addString("world");
             cmd.addString("mk");
             cmd.addString("ssph");
-                
+
             // radius
             cmd.addDouble(0.02);
 
@@ -234,7 +234,7 @@ public:
             cmd.addDouble(0.0);
             cmd.addDouble(0.0);
             cmd.addDouble(0.0);
-                
+
             // color
             cmd.addInt(1);
             cmd.addInt(0);
@@ -296,7 +296,7 @@ public:
         if ((c_.length()!=3) && (c_.length()!=4))
             return;
 
-        Vector c=c_;        
+        Vector c=c_;
         if (c.length()==3)
             c.push_back(1.0);
         c[3]=1.0;
@@ -462,7 +462,7 @@ public:
 
         reachingHandler(b0,pos,rpy);
         handHandler(b1);
-        
+
         if (!b0 && !b1)
         {
             if (norm(feedback)>0.0)
@@ -476,7 +476,7 @@ public:
             size_t sz=std::min(feedback.length(),(size_t)bForce->size());
             for (size_t i=0; i<sz; i++)
             {
-                feedback[i]=bForce->get(i).asDouble();
+                feedback[i]=bForce->get(i).asFloat64();
                 if ((feedback[i]>=-minForce) && (feedback[i]<=minForce))
                     feedback[i]=0.0;
                 else if (feedback[i]<=-maxForce)
@@ -516,5 +516,3 @@ int main(int argc,char *argv[])
     TeleOp teleop;
     return teleop.runModule(rf);
 }
-
-

--- a/wrapper/hapticdeviceWrapper.cpp
+++ b/wrapper/hapticdeviceWrapper.cpp
@@ -7,8 +7,9 @@
  *
  */
 
+#include <mutex>
+
 #include <yarp/os/Log.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
 
@@ -26,7 +27,7 @@ using namespace yarp::math;
 
 /*********************************************************************/
 HapticDeviceWrapper::HapticDeviceWrapper() :
-                     RateThread(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD),
+                     PeriodicThread(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD),
                      device(NULL), applyFdbck(false), fdbck(3,0.0)
 {
 }
@@ -45,15 +46,14 @@ bool HapticDeviceWrapper::open(Searchable &config)
 {
     portStemName=config.check("name",
                               Value(HAPTICDEVICE_WRAPPER_DEFAULT_NAME)).asString().c_str();
-    verbosity=config.check("verbosity",Value(0)).asInt();
+    verbosity=config.check("verbosity",Value(0)).asInt32();
     int period=config.check("period",
-                            Value(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD)).asInt();
-    setRate(period);
+                            Value(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD)).asInt32();
+    setPeriod(period);
 
     if (config.check("subdevice"))
     {
         Property p(config.toString().c_str());
-        p.setMonitor(config.getMonitor(),"subdevice");
         p.unput("device");
         p.put("device",config.find("subdevice").asString());
 
@@ -68,7 +68,7 @@ bool HapticDeviceWrapper::open(Searchable &config)
             yError("*** Haptic Device Wrapper: failed to open the driver!");
             return false;
         }
-    }    
+    }
 
     if (verbosity>0)
         yInfo("*** Haptic Device Wrapper: opened");
@@ -80,7 +80,7 @@ bool HapticDeviceWrapper::open(Searchable &config)
 /*********************************************************************/
 bool HapticDeviceWrapper::close()
 {
-    LockGuard lg(mutex);
+    std::lock_guard lg(mutex);
     if (isRunning())
     {
         askToStop();
@@ -92,7 +92,7 @@ bool HapticDeviceWrapper::close()
 
     if (driver.isValid())
         driver.close();
-    
+
     if (verbosity>0)
         yInfo("*** Haptic Device Wrapper: closed");
 
@@ -133,14 +133,14 @@ bool HapticDeviceWrapper::attachAll(const PolyDriverList &p)
 
     if (device==NULL)
     {
-        yError("*** Haptic Device Wrapper: invalid device"); 
+        yError("*** Haptic Device Wrapper: invalid device");
         return false;
     }
 
     start();
     if (verbosity>0)
         yInfo("*** Haptic Device Wrapper: started");
-    
+
     return true;
 }
 
@@ -159,12 +159,12 @@ bool HapticDeviceWrapper::read(ConnectionReader &connection)
     Bottle cmd;
     if (!cmd.read(connection))
         return false;
-    int tag=cmd.get(0).asVocab();
+    int tag=cmd.get(0).asVocab32();
 
     Bottle rep;
     if (device!=NULL)
     {
-        LockGuard lg(mutex);
+        std::lock_guard lg(mutex);
 
         if (tag==hapticdevice::set_transformation)
         {
@@ -172,19 +172,19 @@ bool HapticDeviceWrapper::read(ConnectionReader &connection)
             {
                 if (Bottle *payload=cmd.get(1).asList())
                 {
-                    Matrix T(payload->get(0).asInt(),
-                             payload->get(1).asInt());
-            
+                    Matrix T(payload->get(0).asInt32(),
+                             payload->get(1).asInt32());
+
                     if (Bottle *vals=payload->get(2).asList())
                     {
                         for (int r=0; r<T.rows(); r++)
                             for (int c=0; c<T.cols(); c++)
-                                T(r,c)=vals->get(T.rows()*r+c).asDouble();
-            
+                                T(r,c)=vals->get(T.rows()*r+c).asFloat64();
+
                         if (device->setTransformation(T))
-                            rep.addVocab(hapticdevice::ack);
+                            rep.addVocab32(hapticdevice::ack);
                         else
-                            rep.addVocab(hapticdevice::nack);
+                            rep.addVocab32(hapticdevice::nack);
                     }
                 }
             }
@@ -194,55 +194,55 @@ bool HapticDeviceWrapper::read(ConnectionReader &connection)
             Matrix T;
             if (device->getTransformation(T))
             {
-                rep.addVocab(hapticdevice::ack);
+                rep.addVocab32(hapticdevice::ack);
                 rep.addList().read(T);
             }
             else
-                rep.addVocab(hapticdevice::nack);
+                rep.addVocab32(hapticdevice::nack);
         }
         else if (tag==hapticdevice::stop_feedback)
         {
             fdbck=0.0;
             device->stopFeedback();
             applyFdbck=false;
-            rep.addVocab(hapticdevice::ack);
+            rep.addVocab32(hapticdevice::ack);
         }
         else if (tag==hapticdevice::is_cartesian)
         {
             bool ret;
             if (device->isCartesianForceModeEnabled(ret))
             {
-                rep.addVocab(hapticdevice::ack);
-                rep.addInt(ret?1:0);
+                rep.addVocab32(hapticdevice::ack);
+                rep.addInt32(ret?1:0);
             }
             else
-                rep.addVocab(hapticdevice::nack);
+                rep.addVocab32(hapticdevice::nack);
         }
         else if (tag==hapticdevice::set_cartesian)
         {
-            rep.addVocab(device->setCartesianForceMode()?
+            rep.addVocab32(device->setCartesianForceMode()?
                          hapticdevice::ack:hapticdevice::nack);
         }
         else if (tag==hapticdevice::set_joint)
         {
-            rep.addVocab(device->setJointTorqueMode()?
+            rep.addVocab32(device->setJointTorqueMode()?
                          hapticdevice::ack:hapticdevice::nack);
         }
         else if (tag==hapticdevice::get_max)
         {
             Vector max;
             if (device->getMaxFeedback(max))
-            {               
-                rep.addVocab(hapticdevice::ack);
-                rep.addList().read(max);                
+            {
+                rep.addVocab32(hapticdevice::ack);
+                rep.addList().read(max);
             }
             else
-                rep.addVocab(hapticdevice::nack);
+                rep.addVocab32(hapticdevice::nack);
         }
     }
 
     if (rep.size()==0)
-        rep.addVocab(hapticdevice::nack);
+        rep.addVocab32(hapticdevice::nack);
 
     ConnectionWriter *writer=connection.getWriter();
     if (writer!=NULL)
@@ -282,13 +282,13 @@ void HapticDeviceWrapper::run()
 {
     if (device!=NULL)
     {
-        LockGuard lg(mutex);
+        std::lock_guard lg(mutex);
 
         Vector pos,rpy,buttons;
         device->getPosition(pos);
         device->getOrientation(rpy);
         device->getButtons(buttons);
-        
+
         Vector output=cat(cat(pos,rpy),buttons);
         statePort.prepare().read(output);
 
@@ -300,9 +300,9 @@ void HapticDeviceWrapper::run()
         {
             if (fdbck->size()>=3)
             {
-                this->fdbck[0]=fdbck->get(0).asDouble();
-                this->fdbck[1]=fdbck->get(1).asDouble();
-                this->fdbck[2]=fdbck->get(2).asDouble();
+                this->fdbck[0]=fdbck->get(0).asFloat64();
+                this->fdbck[1]=fdbck->get(1).asFloat64();
+                this->fdbck[2]=fdbck->get(2).asFloat64();
             }
 
             applyFdbck=true;
@@ -312,4 +312,3 @@ void HapticDeviceWrapper::run()
             device->setFeedback(fdbck);
     }
 }
-

--- a/wrapper/hapticdeviceWrapper.cpp
+++ b/wrapper/hapticdeviceWrapper.cpp
@@ -17,7 +17,7 @@
 #include "common.h"
 
 #define HAPTICDEVICE_WRAPPER_DEFAULT_NAME       "hapticdevice"
-#define HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD     20          // [ms]
+#define HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD     0.02 // [s]
 
 using namespace std;
 using namespace yarp::os;
@@ -48,7 +48,7 @@ bool HapticDeviceWrapper::open(Searchable &config)
                               Value(HAPTICDEVICE_WRAPPER_DEFAULT_NAME)).asString().c_str();
     verbosity=config.check("verbosity",Value(0)).asInt32();
     int period=config.check("period",
-                            Value(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD)).asInt32();
+                            Value(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD)).asFloat64();
     setPeriod(period);
 
     if (verbosity>0)

--- a/wrapper/hapticdeviceWrapper.cpp
+++ b/wrapper/hapticdeviceWrapper.cpp
@@ -51,25 +51,6 @@ bool HapticDeviceWrapper::open(Searchable &config)
                             Value(HAPTICDEVICE_WRAPPER_DEFAULT_PERIOD)).asInt32();
     setPeriod(period);
 
-    if (config.check("subdevice"))
-    {
-        Property p(config.toString().c_str());
-        p.unput("device");
-        p.put("device",config.find("subdevice").asString());
-
-        if (driver.open(p))
-        {
-            IHapticDevice *d;
-            driver.view(d);
-            attach(d);
-        }
-        else
-        {
-            yError("*** Haptic Device Wrapper: failed to open the driver!");
-            return false;
-        }
-    }
-
     if (verbosity>0)
         yInfo("*** Haptic Device Wrapper: opened");
 
@@ -101,39 +82,11 @@ bool HapticDeviceWrapper::close()
 
 
 /*********************************************************************/
-void HapticDeviceWrapper::attach(IHapticDevice *dev)
+bool HapticDeviceWrapper::attach(PolyDriver *dev)
 {
-    device=dev;
-
-    start();
-    if (verbosity>0)
-        yInfo("*** Haptic Device Wrapper: started");
-}
-
-
-/*********************************************************************/
-void HapticDeviceWrapper::detach()
-{
-    device=NULL;
-}
-
-
-/*********************************************************************/
-bool HapticDeviceWrapper::attachAll(const PolyDriverList &p)
-{
-    if (p.size()!=1)
+    if (!dev || !dev->isValid() || !dev->view(device)) 
     {
-        yError("*** Haptic Device Wrapper: cannot attach more than one device");
-        return false;
-    }
-
-    PolyDriver *dev=p[0]->poly;
-    if (dev->isValid())
-        dev->view(device);
-
-    if (device==NULL)
-    {
-        yError("*** Haptic Device Wrapper: invalid device");
+        yError("Cannot view IHapticDevice");
         return false;
     }
 
@@ -146,12 +99,11 @@ bool HapticDeviceWrapper::attachAll(const PolyDriverList &p)
 
 
 /*********************************************************************/
-bool HapticDeviceWrapper::detachAll()
+bool HapticDeviceWrapper::detach()
 {
-    device=NULL;
+    device=nullptr;
     return true;
 }
-
 
 /*********************************************************************/
 bool HapticDeviceWrapper::read(ConnectionReader &connection)

--- a/wrapper/hapticdeviceWrapper.h
+++ b/wrapper/hapticdeviceWrapper.h
@@ -20,7 +20,7 @@
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/WrapperSingle.h>
 #include <yarp/dev/IHapticDevice.h>
 #include <yarp/sig/Vector.h>
 
@@ -28,7 +28,7 @@
  * Haptic Device wrapper
  */
 class HapticDeviceWrapper : public yarp::dev::DeviceDriver,
-                            public yarp::dev::IMultipleWrapper,
+                            public yarp::dev::WrapperSingle,
                             public yarp::os::PeriodicThread,
                             public yarp::os::PortReader
 {
@@ -49,23 +49,20 @@ protected:
     yarp::sig::Vector fdbck;
     bool applyFdbck;
 
-    bool read(yarp::os::ConnectionReader &connection);
-    bool threadInit();
-    void threadRelease();
-    void run();
+    bool read(yarp::os::ConnectionReader &connection) override;
+    bool threadInit() override;
+    void threadRelease() override;
+    void run() override;
 
 public:
     HapticDeviceWrapper();
-    ~HapticDeviceWrapper();
+    ~HapticDeviceWrapper() override;
 
-    bool open(yarp::os::Searchable &config);
-    bool close();
+    bool open(yarp::os::Searchable &config) override;
+    bool close() override;
 
-    void attach(yarp::dev::IHapticDevice *dev);
-    void detach();
-
-    bool attachAll(const yarp::dev::PolyDriverList &p);
-    bool detachAll();
+    bool attach(yarp::dev::PolyDriver *dev) override;
+    bool detach() override;
 };
 
 #endif

--- a/wrapper/hapticdeviceWrapper.h
+++ b/wrapper/hapticdeviceWrapper.h
@@ -11,16 +11,16 @@
 #define __HAPTICDEVICE_WRAPPER__
 
 #include <string>
+#include <mutex>
 
-#include <yarp/os/RateThread.h>
+#include <yarp/os/PeriodicThread.h>
 #include <yarp/os/PortReader.h>
 #include <yarp/os/RpcServer.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/IHapticDevice.h>
 #include <yarp/sig/Vector.h>
 
@@ -29,7 +29,7 @@
  */
 class HapticDeviceWrapper : public yarp::dev::DeviceDriver,
                             public yarp::dev::IMultipleWrapper,
-                            public yarp::os::RateThread,
+                            public yarp::os::PeriodicThread,
                             public yarp::os::PortReader
 {
 protected:
@@ -39,8 +39,8 @@ protected:
     yarp::os::BufferedPort<yarp::os::Bottle> statePort;
     yarp::os::BufferedPort<yarp::os::Bottle> feedbackPort;
     yarp::os::RpcServer                      rpcPort;
-    
-    yarp::os::Mutex mutex;
+
+    std::mutex mutex;
     yarp::os::Stamp stamp;
 
     yarp::dev::PolyDriver driver;
@@ -69,5 +69,3 @@ public:
 };
 
 #endif
-
-


### PR DESCRIPTION
According to latest YARP practices, drop subdevices support in favor of device attaching. Also bump to YARP 3.12 and CMake 3.19.